### PR TITLE
Fix multiple migration failures on postgresql

### DIFF
--- a/db/migrate/11_fix_usda_weights.rb
+++ b/db/migrate/11_fix_usda_weights.rb
@@ -9,7 +9,8 @@ class FixUsdaWeights < ActiveRecord::Migration
         :nutrient_databank_number,
         :sequence_number
       ], {
-        unique: true
+        unique: true,
+        name: 'index_usda_weights_on_nutrient_databank_number_and_seq_number'
       }
     end
   end

--- a/db/migrate/12_fix_usda_foods_nutrients.rb
+++ b/db/migrate/12_fix_usda_foods_nutrients.rb
@@ -3,10 +3,7 @@ class FixUsdaFoodsNutrients < ActiveRecord::Migration
     remove_column :usda_foods_nutrients, :id
 
     change_table :usda_foods_nutrients do |t|
-      t.remove_index [
-        :nutrient_databank_number,
-        :nutrient_number
-      ]
+      t.remove_index name: 'index_usda_foods_nutrients_on_databank_number_and_number'
     end
   end
 end

--- a/db/migrate/9_add_referential_integrity.rb
+++ b/db/migrate/9_add_referential_integrity.rb
@@ -48,35 +48,5 @@ class AddReferentialIntegrity < ActiveRecord::Migration
       :usda_foods,
       column: :nutrient_databank_number,
       primary_key: :nutrient_databank_number
-
-    add_foreign_key :usda_foods,
-      :usda_food_groups,
-      column: :food_group_code,
-      primary_key: :code
-
-    add_foreign_key :usda_foods_nutrients,
-      :usda_foods,
-      column: :nutrient_databank_number,
-      primary_key: :nutrient_databank_number
-
-    add_foreign_key :usda_foods_nutrients,
-      :usda_nutrients,
-      column: :nutrient_number,
-      primary_key: :nutrient_number
-
-    add_foreign_key :usda_foods_nutrients,
-      :usda_source_codes,
-      column: :src_code,
-      primary_key: :code
-
-    add_foreign_key :usda_footnotes,
-      :usda_foods,
-      column: :nutrient_databank_number,
-      primary_key: :nutrient_databank_number
-
-    add_foreign_key :usda_weights,
-      :usda_foods,
-      column: :nutrient_databank_number,
-      primary_key: :nutrient_databank_number
   end
 end


### PR DESCRIPTION
The duplication was leading to the following error:

```
ActiveRecord::StatementInvalid: PG::DuplicateObject: ERROR:  constraint "fk_rails_0d82ac9394" for relation "usda_foods" already exists
: ALTER TABLE "usda_foods" ADD CONSTRAINT "fk_rails_0d82ac9394"
FOREIGN KEY ("food_group_code")
  REFERENCES "usda_food_groups" ("code")
```
